### PR TITLE
fix: clear buffer before updating with new markdown

### DIFF
--- a/lua/docs-view.lua
+++ b/lua/docs-view.lua
@@ -33,6 +33,7 @@ local function update()
       end
 
       vim.api.nvim_buf_set_option(buf, "modifiable", true)
+      vim.api.nvim_buf_set_lines(buf, 0, -1, true, {})
       vim.lsp.util.stylize_markdown(buf, md_lines)
       vim.api.nvim_buf_set_option(buf, "modifiable", false)
     end


### PR DESCRIPTION
Before: Given two sets of hover documentation, a) longer text (more lines) and b) shorter text (fewer lines).. when moving from a) to b), the extra lines from a remain in the buffer.

After: With this change, the buffer is cleared before adding new hover text, thus removing the excess trailing lines from any previous hover text.