### PR TITLE
Set window height only when cfg.position is bottom or top

### DIFF
--- a/lua/docs-view.lua
+++ b/lua/docs-view.lua
@@ -74,7 +74,9 @@ M.toggle = function()
     win = vim.api.nvim_get_current_win()
     buf = vim.api.nvim_get_current_buf()
 
-    vim.api.nvim_win_set_height(win, math.ceil(height))
+    if cfg.position == "bottom" or cfg.position == "top" then
+        vim.api.nvim_win_set_height(win, math.ceil(height))
+    end
     vim.api.nvim_win_set_width(win, math.ceil(width))
 
     vim.api.nvim_buf_set_name(buf, "Docs View")

--- a/lua/docs-view.lua
+++ b/lua/docs-view.lua
@@ -65,10 +65,8 @@ M.toggle = function()
       width = vim.api.nvim_win_get_height(prev_win)
     elseif cfg.position == "left" then
       vim.api.nvim_command("topleft vnew")
-      height = vim.api.nvim_win_get_height(prev_win)
     else
       vim.api.nvim_command("botright vnew")
-      height = vim.api.nvim_win_get_height(prev_win)
     end
 
     win = vim.api.nvim_get_current_win()


### PR DESCRIPTION
Fixes #13

Set the window height only when `cfg.position` is `"bottom"` or `"top"` to prevent the window height from becoming too low after `:DocsViewToggle` is executed.

Tested with Neovim v0.10.2 and v0.9.5. v0.8.x and earlier versions are not tested as they are not supported by lspconfig.