### PR TITLE
Remove deprecated calls

### DIFF
--- a/lua/docs-view.lua
+++ b/lua/docs-view.lua
@@ -24,7 +24,7 @@ M.update = function()
   vim.lsp.buf_request(0, "textDocument/hover", {
     textDocument = { uri = "file://" .. vim.api.nvim_buf_get_name(0) },
     position = { line = l - 1, character = c },
-  }, function(err, result, ctx, config)
+  }, function(err, result, ctx)
     if win and vim.api.nvim_win_is_valid(win) and result and result.contents then
       local md_lines = vim.lsp.util.convert_input_to_markdown_lines(result.contents)
       --md_lines = vim.lsp.util.trim_empty_lines(md_lines)

--- a/lua/docs-view.lua
+++ b/lua/docs-view.lua
@@ -27,7 +27,7 @@ M.update = function()
   }, function(err, result, ctx, config)
     if win and vim.api.nvim_win_is_valid(win) and result and result.contents then
       local md_lines = vim.lsp.util.convert_input_to_markdown_lines(result.contents)
-      md_lines = vim.lsp.util.trim_empty_lines(md_lines)
+      --md_lines = vim.lsp.util.trim_empty_lines(md_lines)
       if vim.tbl_isempty(md_lines) then
         return
       end
@@ -112,7 +112,11 @@ M.setup = function(user_cfg)
 
   cfg = vim.tbl_extend("force", default_cfg, user_cfg)
 
-  if vim.fn.has("nvim-0.8.0") then
+  if vim.fn.has("nvim-0.11.0") then
+    get_clients = function()
+      return vim.lsp.get_clients()
+    end
+  elseif vim.fn.has("nvim-0.8.0") then
     get_clients = function()
       return vim.lsp.get_active_clients()
     end


### PR DESCRIPTION
I fixed some deprecated calls, specifically vim.lsp.get_active_clients and vim.lsp.util.trim_empty_lines which are slated for removal in nvim 0.12.0.

I wasn't sure what the point of trim empty lines was, So I disabled, if you want and try and find a new api for.