### PR TITLE
fix: conceal markdown escape chars in docs view

### DIFF
--- a/lua/docs-view.lua
+++ b/lua/docs-view.lua
@@ -83,6 +83,8 @@ M.toggle = function()
     vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
     vim.api.nvim_buf_set_option(buf, "filetype", "nvim-docs-view")
     vim.api.nvim_buf_set_option(buf, "buflisted", false)
+    vim.api.nvim_win_set_option(win, "conceallevel", 2)
+    vim.api.nvim_win_set_option(win, "concealcursor", "nc")
 
     vim.api.nvim_set_current_win(prev_win)
 


### PR DESCRIPTION
Closes #18.

LSP servers return hover content as GFM (GitHub flavored markdown), escaping `.`, `+`, `_` etc. with `\`. The `lsp_markdown` syntax (applied by `stylize_markdown`) already has conceal rules for these escapes, but conceal only renders when the window has `conceallevel=2`. Plugin wasn't setting it.

Fix: set `conceallevel=2` and `concealcursor=nc` on the docs view window in `M.toggle()`.

Note: escapes inside inline code spans (`` `Class\.Property` ``) still render literally — `lsp_markdown`'s `markdownCode` region only contains `markdownLineStart`, not `markdownEscape`. Out of scope for this fix; the issue's example is consistent with prose-context escapes.
