### PR TITLE
Remove deprecated calls

### DIFF
--- a/lua/docs-view.lua
+++ b/lua/docs-view.lua
@@ -32,10 +32,10 @@ M.update = function()
         return
       end
 
-      vim.api.nvim_buf_set_option(buf, "modifiable", true)
+      vim.api.nvim_set_option_value("modifiable", true, { buf = buf })
       vim.api.nvim_buf_set_lines(buf, 0, -1, true, {})
-      vim.lsp.util.stylize_markdown(buf, md_lines)
-      vim.api.nvim_buf_set_option(buf, "modifiable", false)
+      pcall(vim.treesitter.start, buf, "markdown")
+      vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
     end
   end)
 end
@@ -86,13 +86,13 @@ M.toggle = function()
     vim.api.nvim_win_set_width(win, math.ceil(width))
 
     vim.api.nvim_buf_set_name(buf, "[Docs View]")
-    vim.api.nvim_buf_set_option(buf, "buftype", "nofile")
-    vim.api.nvim_buf_set_option(buf, "swapfile", false)
-    vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
-    vim.api.nvim_buf_set_option(buf, "filetype", "nvim-docs-view")
-    vim.api.nvim_buf_set_option(buf, "buflisted", false)
-    vim.api.nvim_win_set_option(win, "conceallevel", 2)
-    vim.api.nvim_win_set_option(win, "concealcursor", "nc")
+    vim.api.nvim_set_option_value("buftype", "nofile", { buf = buf })
+    vim.api.nvim_set_option_value("swapfile", false, { buf = buf })
+    vim.api.nvim_set_option_value("bufhidden", "wipe", { buf = buf })
+    vim.api.nvim_set_option_value("filetype", "nvim-docs-view", { buf = buf })
+    vim.api.nvim_set_option_value("buflisted", false, { buf = buf })
+    vim.api.nvim_set_option_value("conceallevel", 2, { win = win })
+    vim.api.nvim_set_option_value("concealcursor", "nc", { win = win })
 
     vim.api.nvim_set_current_win(prev_win)
 
@@ -128,11 +128,11 @@ M.setup = function(user_cfg)
     end
   elseif vim.fn.has("nvim-0.8.0") then
     get_clients = function()
-      return vim.lsp.get_active_clients()
+      return vim.lsp.get_clients()
     end
   else
     get_clients = function()
-      return vim.lsp.buf_get_clients(0)
+      return vim.lsp.get_clients({ bufnr = 0 })
     end
   end
 

--- a/lua/docs-view.lua
+++ b/lua/docs-view.lua
@@ -33,7 +33,7 @@ M.update = function()
       end
 
       vim.api.nvim_set_option_value("modifiable", true, { buf = buf })
-      vim.api.nvim_buf_set_lines(buf, 0, -1, true, {})
+      vim.api.nvim_buf_set_lines(buf, 0, -1, true, md_lines)
       pcall(vim.treesitter.start, buf, "markdown")
       vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
     end


### PR DESCRIPTION
### Changes Made
- Replaced deprecated `vim.lsp.get_active_clients()` and `vim.lsp.buf_get_clients()` with the modern `vim.lsp.get_clients()` API.
- Migrated `vim.api.nvim_buf_set_option` and `vim.api.nvim_win_set_option` to `vim.api.nvim_set_option_value` 
- Cleaned up deprecated utility calls, including `vim.lsp.util.trim_empty_lines` and `vim.lsp.util.stylize_markdown` (migrated to `vim.treesitter.start`).